### PR TITLE
Add missing declaration of count variable in sequence_barrier_group.hpp

### DIFF
--- a/include/disruptorplus/sequence_barrier_group.hpp
+++ b/include/disruptorplus/sequence_barrier_group.hpp
@@ -161,6 +161,8 @@ namespace disruptorplus
         {
             assert(!m_sequences.empty());
             
+            size_t count = m_sequences.size();
+            
             sequence_t current = minimum_sequence_after(sequence, count, m_sequences.data());
             if (difference(current, sequence) >= 0)
             {
@@ -198,6 +200,8 @@ namespace disruptorplus
             const std::chrono::time_point<Clock, Duration>& timeoutTime) const
         {
             assert(!m_sequences.empty());
+            
+            size_t count = m_sequences.size();
             
             sequence_t current = minimum_sequence_after(sequence, count, m_sequences.data());
             if (difference(current, sequence) >= 0)


### PR DESCRIPTION
As is, sequence_barrier_group.hpp is missing a local declaration of a variable, which causes it to fail to compile. 

I assumed it was supposed to be the same as this [other usage](https://github.com/lewissbaker/disruptorplus/blob/master/include/disruptorplus/sequence_barrier_group.hpp#L124), so I copied it :) 